### PR TITLE
Allow parser switch during parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Sassone
 ====
 
-[![Test suite](https://github.com/qcam/sassone/actions/workflows/test.yml/badge.svg)](https://github.com/qcam/sassone/actions/workflows/test.yml)
+[![Test suite](https://github.com/sibill-it/sassone/actions/workflows/test.yml/badge.svg)](https://github.com/sibill-it/sassone/actions/workflows/test.yml)
 [![Module Version](https://img.shields.io/hexpm/v/sassone.svg)](https://hex.pm/packages/sassone)
 
 Sassone is an XML SAX parser and encoder in Elixir that focuses on speed, usability and standard compliance.
@@ -187,7 +187,7 @@ already made it happen 💪:
 * https://github.com/bennyhat/xml_json
 * https://github.com/xinz/sax_map
 
-Alternatively, this [pull request](https://github.com/qcam/sassone/pull/78) could
+Alternatively, this [pull request](https://github.com/qcam/saxy/pull/78) could
 serve as a good reference if you want to implement your own map-based handler.
 
 ### Does Sassone work with XPath?
@@ -216,7 +216,7 @@ against.
 
 Therefore the conclusion in this section is only for reference purpose. Please
 feel free to benchmark against your target documents. The benchmark suite can be found
-in [bench/](https://github.com/qcam/sassone/tree/master/bench).
+in [bench/](https://github.com/sibill-it/sassone/tree/master/bench).
 
 A rule of thumb is that we should compare apple to apple. Some XML parsers
 target only specific types of XML. Therefore some indicators are provided in the
@@ -240,13 +240,13 @@ Some quick and biased conclusions from the benchmark suite:
 
 ## Contributing
 
-If you have any issues or ideas, feel free to write to https://github.com/qcam/sassone/issues.
+If you have any issues or ideas, feel free to write to https://github.com/sibill-it/sassone/issues.
 
 To start developing:
 
 1. Fork the repository.
 2. Write your code and related tests.
-3. Create a pull request at https://github.com/qcam/sassone/pulls.
+3. Create a pull request at https://github.com/sibill-it/sassone/pulls.
 
 ## Copyright and License
 

--- a/lib/sassone/emitter.ex
+++ b/lib/sassone/emitter.ex
@@ -12,18 +12,17 @@ defmodule Sassone.Emitter do
     end
   end
 
-  defp emit(event_type, data, %State{user_state: user_state, handler: handler} = state) do
-    case do_emit(event_type, data, handler, user_state) do
+  defp emit(event_type, data, %State{} = state) do
+    case state.handler.handle_event(event_type, data, state.user_state) do
+      {:cont, handler, user_state} ->
+        {:ok, %{state | handler: handler, state: user_state}}
+
       {result, user_state} when result in [:ok, :stop, :halt] ->
         {result, %{state | user_state: user_state}}
 
       other ->
         Parser.Utils.bad_return_error({event_type, other})
     end
-  end
-
-  defp do_emit(event_type, data, handler, user_state) do
-    handler.handle_event(event_type, data, user_state)
   end
 
   @compile {:inline, [convert_entity_reference: 2]}

--- a/lib/sassone/handler.ex
+++ b/lib/sassone/handler.ex
@@ -14,6 +14,8 @@ defmodule Sassone.Handler do
 
   Returning `{:ok, new_state}` continues the parsing process with the new state.
 
+  Returning `{:cont, handler, new_state}` continues the parsing process with the new handler module and new state.
+
   Returning `{:stop, anything}` stops the prosing process immediately, and `anything` will be returned.
   This is usually handy when we want to get the desired return without parsing the whole file.
 
@@ -62,27 +64,31 @@ defmodule Sassone.Handler do
       end
   """
 
+  @type t :: module()
+
+  @type cdata_data() :: String.t()
+  @type characters_data() :: String.t()
+  @type end_document_data() :: any()
+  @type end_element_data() :: name :: String.t()
   @type event_name() ::
           :start_document | :end_document | :start_element | :characters | :cdata | :end_element
-
   @type start_document_data() :: Keyword.t()
-  @type end_document_data() :: any()
   @type start_element_data() ::
           {name :: String.t(), attributes :: [{name :: String.t(), value :: String.t()}]}
-  @type end_element_data() :: name :: String.t()
-  @type characters_data() :: String.t()
-  @type cdata_data() :: String.t()
 
   @type event_data() ::
-          start_document_data()
-          | end_document_data()
-          | start_element_data()
-          | end_element_data()
+          cdata_data()
           | characters_data()
-          | cdata_data()
+          | end_document_data()
+          | end_element_data()
+          | start_document_data()
+          | start_element_data()
+
+  @type user_state() :: any()
 
   @callback handle_event(event_type :: event_name(), data :: event_data(), user_state :: any()) ::
-              {:ok, user_state :: any()}
-              | {:stop, returning :: any()}
-              | {:halt, returning :: any()}
+              {:ok, user_state()}
+              | {:cont, t(), user_state()}
+              | {:stop, user_state()}
+              | {:halt, user_state()}
 end


### PR DESCRIPTION
- Add support for parser switching by returning `{:cont, handler, user_state}` from `Sassone.Handler` callbacks.
- Cleanup `Sassone.Handler` typespecs
- Fix links in README