### PR TITLE
Default namespace to nil in XML functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ to encode the built element into XML binary.
 
 ```elixir
 iex> import Sassone.XML
-iex> element = element(nil, "person", [gender: "female"], [characters("Alice")])
+iex> element = element("person", [gender: "female"], [characters("Alice")])
 {nil, "person", [{"gender", "female"}], [{:characters, "Alice"}]}
 iex> Sassone.encode!(element, [])
 "<?xml version=\"1.0\" encoding=\"utf-8\"?><person gender=\"female\">Alice</person>"

--- a/bench/bench.encoder.exs
+++ b/bench/bench.encoder.exs
@@ -12,23 +12,23 @@ defmodule Bench.Sassone.Builder do
   import Sassone.XML
 
   def build(:simple) do
-    element(nil, "root", [], [
-      element(nil, "element1", [], []),
+    element("root", [], [
+      element("element1", [], []),
       element(
         nil,
         "element2",
         [],
         Enum.map(0..9, fn index ->
-          element(nil, "element2.#{index}", [], [characters("foo")])
+          element("element2.#{index}", [], [characters("foo")])
         end)
       ),
-      element(nil, "element3", [], [])
+      element("element3", [], [])
     ])
   end
 
   def build(:nested) do
-    element(nil, "element", [], [characters("content") | Enum.reduce(1000..1//-1, [], fn index, acc ->
-      [element(nil, "element.#{index}", [], acc)]
+    element("element", [], [characters("content") | Enum.reduce(1000..1//-1, [], fn index, acc ->
+      [element("element.#{index}", [], acc)]
     end)])
   end
 
@@ -42,8 +42,8 @@ defmodule Bench.Sassone.Builder do
       "root",
       [],
       [
-        element(nil, "many-strings", [], Enum.map(@strings, &characters/1)),
-        element(nil, "long-string", [], [characters(@long_string)])
+        element("many-strings", [], Enum.map(@strings, &characters/1)),
+        element("long-string", [], [characters(@long_string)])
       ]
     )
   end

--- a/lib/sassone.ex
+++ b/lib/sassone.ex
@@ -68,7 +68,7 @@ defmodule Sassone do
   to encode the built element into XML binary.
 
       iex> import Sassone.XML
-      iex> element = element(nil, "person", [attribute(nil, "gender", "female")], ["Alice"])
+      iex> element = element("person", [attribute("gender", "female")], ["Alice"])
       {nil, "person", [{nil, "gender", "female"}], ["Alice"]}
       iex> Sassone.encode!(element, [version: "1.0"])
       "<?xml version=\"1.0\"?><person gender=\"female\">Alice</person>"
@@ -357,7 +357,7 @@ defmodule Sassone do
   ## Examples
 
       iex> import Sassone.XML
-      iex> root = element(nil, "foo", [attribute(nil, "foo", "bar")], ["bar"])
+      iex> root = element("foo", [attribute("foo", "bar")], ["bar"])
       iex> prolog = [version: "1.0"]
       iex> Sassone.encode!(root, prolog)
       "<?xml version=\\"1.0\\"?><foo foo=\\"bar\\">bar</foo>"
@@ -380,7 +380,7 @@ defmodule Sassone do
   ## Examples
 
       iex> import Sassone.XML
-      iex> root = element(nil, "foo", [attribute(nil, "foo", "bar")], ["bar"])
+      iex> root = element("foo", [attribute("foo", "bar")], ["bar"])
       iex> prolog = [version: "1.0"]
       iex> Sassone.encode_to_iodata!(root, prolog)
       [

--- a/lib/sassone/xml.ex
+++ b/lib/sassone/xml.ex
@@ -36,11 +36,14 @@ defmodule Sassone.XML do
   @compile {
     :inline,
     [
+      attribute: 2,
       attribute: 3,
       cdata: 1,
       characters: 1,
       comment: 1,
+      element: 3,
       element: 4,
+      empty_element: 2,
       empty_element: 3,
       processing_instruction: 2,
       reference: 2
@@ -52,16 +55,16 @@ defmodule Sassone.XML do
 
   @doc "Builds attribute in simple form."
   @spec attribute(namespace(), name(), value()) :: attribute()
-  def attribute(namespace, name, value), do: {namespace, name, Encoder.encode(value)}
+  def attribute(namespace \\ nil, name, value), do: {namespace, name, Encoder.encode(value)}
 
   @doc "Builds empty element in simple form."
   @spec empty_element(namespace(), name(), [attribute()]) :: element()
-  def empty_element(namespace, name, attributes),
+  def empty_element(namespace \\ nil, name, attributes),
     do: {namespace, name, attributes, []}
 
   @doc "Builds element in simple form."
   @spec element(namespace(), name(), [attribute()], [content()]) :: element()
-  def element(namespace, name, attributes, children),
+  def element(namespace \\ nil, name, attributes, children),
     do: {namespace, name, attributes, children}
 
   @doc "Builds characters in simple form."
@@ -116,7 +119,7 @@ defmodule Sassone.XML do
   defp build_attribute(_field, nil, attributes), do: attributes
 
   defp build_attribute(field, value, attributes),
-    do: [attribute(nil, field.xml_name, value) | attributes]
+    do: [attribute(field.xml_name, value) | attributes]
 
   defp build_elements(_struct, %Field{build: false}, elements),
     do: elements
@@ -136,7 +139,7 @@ defmodule Sassone.XML do
     if Builder.impl_for(value) do
       [build(value, field.xml_name) | elements]
     else
-      [element(nil, field.xml_name, [], [characters(value)]) | elements]
+      [element(field.xml_name, [], [characters(value)]) | elements]
     end
   end
 end

--- a/test/sassone/xml_test.exs
+++ b/test/sassone/xml_test.exs
@@ -5,15 +5,15 @@ defmodule Sassone.XMLTest do
 
   describe "element/3" do
     test "generates element in simple form" do
-      assert element(nil, "foo", [], []) == {nil, "foo", [], []}
-      assert element(nil, "foo", [{"a", 1}], []) == {nil, "foo", [{"a", 1}], []}
+      assert element("foo", [], []) == {nil, "foo", [], []}
+      assert element("foo", [{"a", 1}], []) == {nil, "foo", [{"a", 1}], []}
     end
   end
 
   describe "empty_element/2" do
     test "generates empty element in simple form" do
-      assert empty_element(nil, "foo", []) == {nil, "foo", [], []}
-      assert empty_element(nil, "foo", [{"a", 1}]) == {nil, "foo", [{"a", 1}], []}
+      assert empty_element("foo", []) == {nil, "foo", [], []}
+      assert empty_element("foo", [{"a", 1}]) == {nil, "foo", [{"a", 1}], []}
     end
   end
 

--- a/test/sassone_test.exs
+++ b/test/sassone_test.exs
@@ -167,7 +167,7 @@ defmodule SassoneTest do
     import Sassone.XML
 
     test "encodes XML document into string" do
-      root = element(nil, "foo", [], ["foo"])
+      root = element("foo", [], ["foo"])
       assert Sassone.encode!(root, version: "1.0") == ~s(<?xml version="1.0"?><foo>foo</foo>)
     end
   end
@@ -176,7 +176,7 @@ defmodule SassoneTest do
     import Sassone.XML
 
     test "encodes XML document into IO data" do
-      root = element(nil, "foo", [], ["foo"])
+      root = element("foo", [], ["foo"])
       assert xml = Sassone.encode_to_iodata!(root, version: "1.0")
       assert is_list(xml)
       assert IO.iodata_to_binary(xml) == ~s(<?xml version="1.0"?><foo>foo</foo>)
@@ -385,18 +385,18 @@ defmodule SassoneTest do
 
       items =
         for index <- 1..2 do
-          element(nil, "item", [], [
-            element(nil, "title", [], ["Item #{index}"]),
-            element(nil, "link", [], ["Link #{index}"]),
+          element("item", [], [
+            element("title", [], ["Item #{index}"]),
+            element("link", [], ["Link #{index}"]),
             comment("Comment #{index}"),
-            element(nil, "description", [], [cdata("<a></b>")]),
+            element("description", [], [cdata("<a></b>")]),
             characters("ABCDEFG"),
             reference(:entity, "copyright")
           ])
         end
 
       xml =
-        element(nil, "rss", [attribute(nil, "version", 2.0)], items)
+        element("rss", [attribute("version", 2.0)], items)
         |> Sassone.encode!(version: "1.0")
 
       expected = """
@@ -428,7 +428,7 @@ defmodule SassoneTest do
       {document, xml} =
         Enum.reduce(100..1//-1, {"content", "content"}, fn index, {document, xml} ->
           {
-            Sassone.XML.element(nil, "level#{index}", [], [document]),
+            Sassone.XML.element("level#{index}", [], [document]),
             "<level#{index}>#{xml}</level#{index}>"
           }
         end)


### PR DESCRIPTION
Default XML namespace to `nil` for XML construction functions `attribute`, `element` and `empty_element`.

This remove the need to pass nil explicitly when a namespace is not required and preserves backwards API compatibility.